### PR TITLE
Closes #10; fix:修复时区找不到的问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ ADD . /app
 
 WORKDIR /app
 
-RUN cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
-    && apk add --no-cache --virtual .build-deps gcc musl-dev libffi-dev openssl-dev bash\
+RUN apk add --no-cache --virtual .build-deps gcc musl-dev libffi-dev openssl-dev bash\
     && apk add --no-cache libffi openssl \
     && pip install --no-cache-dir --upgrade pip setuptools wheel\
     && pip install --no-cache-dir -r requirements.txt \

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ pip install scrapy scrapyd scrapyd-client
 方式三：
 
 ```bash
-docker run -p 8000:8000 mouday/spider-admin-pro
+vim config.yaml # 配置文件文件内容见⬇️：配置参数
+docker run -e TZ=Asia/Shanghai -p 8000:8000 -v ./config.yml:/app/config.yml mouday/spider-admin-pro
 ```
 
 ## 配置参数


### PR DESCRIPTION
Dockerfile中的：`cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime` 并不会生效
因为在tzlocal/unix.py文件中检查本地timezone的代码中：
```Python
tzpath = os.path.join(_root, 'etc/localtime')
if os.path.exists(tzpath) and os.path.islink(tzpath):
    tzpath = os.path.realpath(tzpath)
    start = tzpath.find("/")+1
    while start is not 0:
        tzpath = tzpath[start:]
        try:
            return pytz.timezone(tzpath)
        except pytz.UnknownTimeZoneError:
            pass
        start = tzpath.find("/")+1
```
`os.path.islink(tzpath)`这行代码会检查`/etc/localtime`是否为软连接，直接cp过来的文件不是软连接，不会通过检查，所以最后timezone为None

有两种方式修复：
fix1:
将`cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime`
改为`ln -s /usr/share/zoneinfo/Asia/Shanghai /etc/localtime`
但这样会强制使用Asia/Shanghai时区，失去自由性
fix2:
在Docker启动命令中增加TZ参数`-e TZ=Asia/Shanghai`
这样容器将使用传递的时区信息动态设置 /etc/localtime，而不是在构建镜像时就设置
由于同样issue人数较多，故在README.md中明文增加命令