### PR TITLE
添加响应压缩功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ config.yml
 logs/
 .python-version
 venv/
+.venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN apk add --no-cache --virtual .build-deps gcc musl-dev libffi-dev openssl-dev
     && pip install --no-cache-dir -r requirements.txt \
     && apk del .build-deps
 
-CMD gunicorn --bind '0.0.0.0:8000' 'spider_admin_pro.main:app'
+CMD gunicorn --bind '0.0.0.0:8000' 'spider_admin_pro:app'

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@
 
 # 运行开发环境
 dev:
-	gunicorn --bind '127.0.0.1:5001' --reload 'spider_admin_pro.main:app'
+	gunicorn --bind '127.0.0.1:5001' --reload 'spider_admin_pro:app'
 
 # 运行生产环境
 pro:
-	gunicorn --bind '127.0.0.1:8000' 'spider_admin_pro.main:app'
+	gunicorn --bind '127.0.0.1:8000' 'spider_admin_pro:app'
 
 # 打包
 build:

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ $ pip3 install spider-admin-pro
 $ pip3 install -U spider-admin-pro -i https://pypi.org/simple
 
 # Linux macOS 运行启动
-$ gunicorn 'spider_admin_pro.main:app'
+$ gunicorn 'spider_admin_pro:app'
 
 # windows 环境使用waitress 替换 gunicorn
 $ pip install waitress
 
-$ waitress-serve --listen=127.0.0.1:8000 'spider_admin_pro.main:app'
+$ waitress-serve --listen=127.0.0.1:8000 'spider_admin_pro:app'
 ```
 
 方式二：
@@ -105,7 +105,7 @@ docker run -e TZ=Asia/Shanghai -p 8000:8000 -v ./config.yml:/app/config.yml moud
 $ ls
 config.yml
 
-$ gunicorn 'spider_admin_pro.main:app'
+$ gunicorn 'spider_admin_pro:app'
 ```
 > 强烈建议：修改密码和秘钥项
 
@@ -336,11 +336,11 @@ pip install pywin32
 
 ```bash
 # 启动运行
-$ gunicorn 'spider_admin_pro.main:app'
+$ gunicorn 'spider_admin_pro:app'
 
 # 支持外网可访问，云服务器（阿里云或腾讯云）需要设置安全组 
 # 默认内网访问 --bind 127.0.0.1:8000
-$ gunicorn --bind '0.0.0.0:8000' 'spider_admin_pro.main:app'
+$ gunicorn --bind '0.0.0.0:8000' 'spider_admin_pro:app'
 ```
 
 更多设置，可参考[gunicorn](https://docs.gunicorn.org/en/stable/index.html)

--- a/dev.py
+++ b/dev.py
@@ -5,7 +5,7 @@
 # 预留给windows用户开发使用
 """
 
-from spider_admin_pro.main import app
+from spider_admin_pro import app
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/requirements.py3.6.txt
+++ b/requirements.py3.6.txt
@@ -43,3 +43,4 @@ user-agents==2.2.0
 w3lib==2.0.1
 Werkzeug==2.0.3
 zipp==3.6.0
+Flask-Compress==1.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ ua-parser
 user-agents
 Werkzeug
 gunicorn
+flask-compress

--- a/spider_admin_pro/__init__.py
+++ b/spider_admin_pro/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-from main import app
+from spider_admin_pro.main import app
 
 __all__ = ['app']

--- a/spider_admin_pro/__init__.py
+++ b/spider_admin_pro/__init__.py
@@ -1,1 +1,4 @@
 # -*- coding: utf-8 -*-
+from main import app
+
+__all__ = ['app']

--- a/spider_admin_pro/main.py
+++ b/spider_admin_pro/main.py
@@ -6,8 +6,10 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from spider_admin_pro.router import register_blueprint
 from spider_admin_pro.service import system_task_service
 from spider_admin_pro.utils.flask_ext.flask_app import FlaskApp
+from flask_compress import Compress
 
 app = FlaskApp(__name__, static_folder=None)
+Compress(app)
 CORS(app, supports_credentials=True)
 app.wsgi_app = ProxyFix(app.wsgi_app)
 
@@ -18,7 +20,7 @@ register_blueprint(app)
 @app.before_request
 def before_request():
     """跨域请求会出现options，直接返回即可"""
-    if request.method == 'OPTIONS':
+    if request.method == "OPTIONS":
         return make_response()
 
 


### PR DESCRIPTION
前端文件未进行压缩，大小较大，进入主页速度慢，在3mbps小水管上需要加载10秒左右

未开启压缩功能

![image](https://github.com/mouday/spider-admin-pro/assets/39302391/a6a12e6a-e570-4365-94c7-19502ef91b9c)

开启响应压缩功能后：

![image](https://github.com/mouday/spider-admin-pro/assets/39302391/2189ff06-e2b0-4ced-b131-67b34294f5f1)

而对于纯文本日志来说，其字符排布有大量重复内容，且较为稀疏，日志大小为mb级别较为常见，如图1.5m的纯文本日志在经过http传输后，会编码成2m大小

![image](https://github.com/mouday/spider-admin-pro/assets/39302391/ee335f11-94ec-4ebb-8e4e-498f1042e4b9)

对于有大量重复内容的稀疏文本，压缩率达到了惊人的1.4%，经过压缩后仅为29.9kb，能够极大节省带宽
