### PR TITLE
fix scrapyd_api.py /schedule miss out options

### DIFF
--- a/spider_admin_pro/api/scrapyd_api.py
+++ b/spider_admin_pro/api/scrapyd_api.py
@@ -129,11 +129,13 @@ def schedule():
     project = request.json['project']
     spider = request.json['spider']
     scrapyd_server_id = request.json['scrapydServerId']
+    options = request.json['options']
 
     kwargs = {
         'project': project,
         'spider': spider,
-        'scrapyd_server_id': scrapyd_server_id
+        'scrapyd_server_id': scrapyd_server_id,
+        'options': options
     }
 
     # fix: 记录手动运行日志


### PR DESCRIPTION
修复在定时任务页面点击执行，任务不会带参数执行
https://github.com/mouday/spider-admin-pro/issues/13